### PR TITLE
Refine terminal entrypoint detection

### DIFF
--- a/heyclaude
+++ b/heyclaude
@@ -143,8 +143,11 @@ detect_terminal() {
             return 0
         fi
     done
-    
-    error "No terminal emulator found"
+
+    # Leave TERMINAL_CMD empty so the caller can decide how to handle the
+    # missing terminal scenario gracefully.
+    TERMINAL_CMD=""
+    return 0
 }
 
 # Check for Claude CLI
@@ -408,7 +411,6 @@ main() {
     # Perform detections
     detect_clipboard_tool
     check_claude_cli
-    detect_terminal
     detect_voice_tools
     
     # Load configuration
@@ -453,11 +455,16 @@ main() {
 trap cleanup EXIT
 trap 'INTERRUPTED=true; exit 130' INT TERM
 
-# Check if we need to launch in a new terminal
-if [[ -z "$TERMINAL_CMD" ]] || [[ -t 0 && -t 1 && -t 2 ]]; then
-    # Already in terminal or no terminal needed
+# Determine terminal availability before choosing how to launch
+detect_terminal
+
+if [[ -t 0 && -t 1 && -t 2 ]]; then
+    # Running inside an interactive terminal already
     main
-else
-    # Launch in new terminal
+elif [[ -n "$TERMINAL_CMD" ]]; then
+    # Launch the script inside the detected terminal emulator
     exec $TERMINAL_CMD "$0" "$@"
+else
+    # No terminal available to launch the interactive experience
+    error "Unable to locate a terminal emulator. Run Hey Claude from a terminal or set the TERMINAL environment variable to your preferred launcher."
 fi

--- a/tests/heyclaude_test
+++ b/tests/heyclaude_test
@@ -149,8 +149,9 @@ detect_terminal() {
             return 0
         fi
     done
-    
-    error "No terminal emulator found"
+
+    TERMINAL_CMD=""
+    return 0
 }
 
 # Check for Claude CLI
@@ -414,7 +415,6 @@ main() {
     # Perform detections
     detect_clipboard_tool
     check_claude_cli
-    detect_terminal
     detect_voice_tools
     
     # Load configuration
@@ -459,11 +459,16 @@ main() {
 trap cleanup EXIT
 trap 'INTERRUPTED=true; exit 130' INT TERM
 
-# Check if we need to launch in a new terminal
-if [[ -z "$TERMINAL_CMD" ]] || [[ -t 0 && -t 1 && -t 2 ]]; then
-    # Already in terminal or no terminal needed
+# Determine terminal availability before choosing how to launch
+detect_terminal
+
+if [[ -t 0 && -t 1 && -t 2 ]] || [[ "${HEYCLAUDE_TEST_MODE:-}" == "1" ]]; then
+    # Running inside an interactive terminal already
     main
-else
-    # Launch in new terminal
+elif [[ -n "$TERMINAL_CMD" ]]; then
+    # Launch the script inside the detected terminal emulator
     exec $TERMINAL_CMD "$0" "$@"
+else
+    # No terminal available to launch the interactive experience
+    error "Unable to locate a terminal emulator. Run Hey Claude from a terminal or set the TERMINAL environment variable to your preferred launcher."
 fi

--- a/tests/test_terminal_launch.sh
+++ b/tests/test_terminal_launch.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Verify Hey Claude's terminal detection and entrypoint logic.
+
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+# When a TERMINAL command is provided, the script should exec into it instead
+# of running main. We use /bin/cat to capture the exec path output.
+EXEC_OUTPUT="$TMP_DIR/exec.out"
+TERMINAL=/bin/cat PATH="/usr/bin:/bin" bash "$PROJECT_ROOT/heyclaude" \
+    </dev/null >"$EXEC_OUTPUT" 2>&1
+
+if ! grep -q "# Hey Claude - Ultralight CLI for Claude" "$EXEC_OUTPUT"; then
+    echo "Expected exec path to stream script contents via /bin/cat" >&2
+    exit 1
+fi
+
+# Without a TTY and no detected terminal, the script should fail with a
+# friendly error message instead of invoking main.
+ERROR_STDOUT="$TMP_DIR/error.out"
+ERROR_STDERR="$TMP_DIR/error.err"
+if PATH="/usr/bin:/bin" bash "$PROJECT_ROOT/heyclaude" \
+    </dev/null >"$ERROR_STDOUT" 2>"$ERROR_STDERR"; then
+    echo "Expected Hey Claude to exit with error when no terminal is available" >&2
+    exit 1
+fi
+
+if ! grep -q "Unable to locate a terminal emulator" "$ERROR_STDERR"; then
+    echo "Missing friendly error message when no terminal is found" >&2
+    exit 1
+fi
+
+echo "Terminal detection tests passed."


### PR DESCRIPTION
## Summary
- detect the terminal command before the entrypoint branch so non-TTY launches either exec the emulator or emit a friendly error
- stop re-running terminal detection in main and mirror the behavior in the test harness copy of the script
- add a shell test that exercises both the exec path and friendly error path when the script starts without a TTY

## Testing
- tests/test_terminal_launch.sh


------
https://chatgpt.com/codex/tasks/task_e_68d17db96cf48321a9a61e15be90d931