### PR TITLE
Use array terminal commands

### DIFF
--- a/docs/technical/call_graph.md
+++ b/docs/technical/call_graph.md
@@ -8,7 +8,7 @@ This document maps the function call hierarchy in the Hey Claude script, showing
 graph TD
     A[Script Entry Point] --> B{In Terminal?}
     B -->|Yes| C[main]
-    B -->|No| D[exec TERMINAL_CMD]
+    B -->|No| D[exec TERMINAL_CMD[@]]
     D --> A
     
     C --> E[detect_clipboard_tool]
@@ -51,7 +51,7 @@ graph TD
     │   └─ main() (line 385)
     │
     └─ ELSE launch in terminal
-        └─ exec $TERMINAL_CMD "$0" "$@"
+        └─ exec "${TERMINAL_CMD[@]}" "$0" "$@"
             └─ [Script restarts in terminal]
 ```
 

--- a/docs/technical/execution_flow.md
+++ b/docs/technical/execution_flow.md
@@ -14,14 +14,16 @@ trap 'INTERRUPTED=true; exit 130' INT TERM
 
 ### 2. **Terminal Detection** (Lines 436-441)
 ```bash
-if [[ -z "$TERMINAL_CMD" ]] || [[ -t 0 && -t 1 && -t 2 ]]; then
+if [[ -t 0 && -t 1 && -t 2 ]]; then
     main
+elif (( ${#TERMINAL_CMD[@]} )); then
+    exec "${TERMINAL_CMD[@]}" "$0" "$@"
 else
-    exec $TERMINAL_CMD "$0" "$@"
+    error "Unable to locate a terminal emulator."
 fi
 ```
 - Checks if already running in a terminal
-- If not, launches itself in a new terminal window
+- If not, launches itself in a new terminal window when a command was detected
 
 ### 3. **Main Function Starts** (Line 385)
 The `main()` function orchestrates the entire flow:

--- a/docs/technical/implementation.md
+++ b/docs/technical/implementation.md
@@ -167,8 +167,8 @@ Function to find terminal emulator:
 Logic:
 1. If TERMINAL env var set, use it
 2. Otherwise try common terminals in order
-3. Build command with size and title flags
-4. Set global TERMINAL_CMD variable
+3. Build command array with size and title flags (no embedded quoting)
+4. Set global TERMINAL_CMD array variable
 ```
 
 #### 3.3 Claude CLI Detection

--- a/heyclaude
+++ b/heyclaude
@@ -35,7 +35,7 @@ VOICE_FRAMES=("🎵" "♪" "♫")
 
 # Global state
 CLIPBOARD_TOOL=""
-TERMINAL_CMD=""
+TERMINAL_CMD=()
 HAS_VOICE=false
 CONTINUATION_MODE=false
 OPERATORS=()
@@ -108,14 +108,20 @@ detect_terminal() {
     # Check if already in a terminal
     if [[ -t 0 && -t 1 && -t 2 ]]; then
         # Already in terminal, will run directly
-        TERMINAL_CMD=""
+        TERMINAL_CMD=()
         return 0
     fi
-    
+
     # Check TERMINAL environment variable first
-    if [[ -n "${TERMINAL:-}" ]] && command -v "$TERMINAL" &>/dev/null; then
-        TERMINAL_CMD="$TERMINAL"
-        return 0
+    if [[ -n "${TERMINAL:-}" ]]; then
+        local terminal_words=()
+        # shellcheck disable=SC2086 # intentional evaluation for quoted args
+        if eval "terminal_words=($TERMINAL)"; then
+            if [[ ${#terminal_words[@]} -gt 0 ]] && command -v "${terminal_words[0]}" &>/dev/null; then
+                TERMINAL_CMD=("${terminal_words[@]}")
+                return 0
+            fi
+        fi
     fi
     
     # Try common terminals in order
@@ -125,19 +131,48 @@ detect_terminal() {
         if command -v "$term" &>/dev/null; then
             case "$term" in
                 gnome-terminal)
-                    TERMINAL_CMD="$term --geometry=$DEFAULT_TERMINAL_SIZE --title='Hey Claude' --"
+                    TERMINAL_CMD=(
+                        "$term"
+                        "--geometry=$DEFAULT_TERMINAL_SIZE"
+                        "--title"
+                        "Hey Claude"
+                        "--"
+                    )
                     ;;
                 konsole)
-                    TERMINAL_CMD="$term --geometry=$DEFAULT_TERMINAL_SIZE --title='Hey Claude' -e"
+                    TERMINAL_CMD=(
+                        "$term"
+                        "--geometry=$DEFAULT_TERMINAL_SIZE"
+                        "--title"
+                        "Hey Claude"
+                        "-e"
+                    )
                     ;;
                 alacritty)
-                    TERMINAL_CMD="$term --title 'Hey Claude' -e"
+                    TERMINAL_CMD=(
+                        "$term"
+                        "--title"
+                        "Hey Claude"
+                        "-e"
+                    )
                     ;;
                 kitty)
-                    TERMINAL_CMD="$term --title='Hey Claude' --"
+                    TERMINAL_CMD=(
+                        "$term"
+                        "--title"
+                        "Hey Claude"
+                        "--"
+                    )
                     ;;
                 xterm|terminator)
-                    TERMINAL_CMD="$term -geometry $DEFAULT_TERMINAL_SIZE -title 'Hey Claude' -e"
+                    TERMINAL_CMD=(
+                        "$term"
+                        "-geometry"
+                        "$DEFAULT_TERMINAL_SIZE"
+                        "-title"
+                        "Hey Claude"
+                        "-e"
+                    )
                     ;;
             esac
             return 0
@@ -146,7 +181,7 @@ detect_terminal() {
 
     # Leave TERMINAL_CMD empty so the caller can decide how to handle the
     # missing terminal scenario gracefully.
-    TERMINAL_CMD=""
+    TERMINAL_CMD=()
     return 0
 }
 
@@ -461,9 +496,9 @@ detect_terminal
 if [[ -t 0 && -t 1 && -t 2 ]]; then
     # Running inside an interactive terminal already
     main
-elif [[ -n "$TERMINAL_CMD" ]]; then
+elif (( ${#TERMINAL_CMD[@]} )); then
     # Launch the script inside the detected terminal emulator
-    exec $TERMINAL_CMD "$0" "$@"
+    exec "${TERMINAL_CMD[@]}" "$0" "$@"
 else
     # No terminal available to launch the interactive experience
     error "Unable to locate a terminal emulator. Run Hey Claude from a terminal or set the TERMINAL environment variable to your preferred launcher."

--- a/tests/heyclaude_test
+++ b/tests/heyclaude_test
@@ -35,7 +35,7 @@ VOICE_FRAMES=("🎵" "♪" "♫")
 
 # Global state
 CLIPBOARD_TOOL=""
-TERMINAL_CMD=""
+TERMINAL_CMD=()
 HAS_VOICE=false
 CONTINUATION_MODE=false
 OPERATORS=()
@@ -114,14 +114,20 @@ detect_terminal() {
     # Check if already in a terminal
     if [[ -t 0 && -t 1 && -t 2 ]] || [[ "${HEYCLAUDE_TEST_MODE:-}" == "1" ]]; then
         # Already in terminal, will run directly
-        TERMINAL_CMD=""
+        TERMINAL_CMD=()
         return 0
     fi
-    
+
     # Check TERMINAL environment variable first
-    if [[ -n "${TERMINAL:-}" ]] && command -v "$TERMINAL" &>/dev/null; then
-        TERMINAL_CMD="$TERMINAL"
-        return 0
+    if [[ -n "${TERMINAL:-}" ]]; then
+        local terminal_words=()
+        # shellcheck disable=SC2086 # intentional evaluation for quoted args
+        if eval "terminal_words=($TERMINAL)"; then
+            if [[ ${#terminal_words[@]} -gt 0 ]] && command -v "${terminal_words[0]}" &>/dev/null; then
+                TERMINAL_CMD=("${terminal_words[@]}")
+                return 0
+            fi
+        fi
     fi
     
     # Try common terminals in order
@@ -131,26 +137,55 @@ detect_terminal() {
         if command -v "$term" &>/dev/null; then
             case "$term" in
                 gnome-terminal)
-                    TERMINAL_CMD="$term --geometry=$DEFAULT_TERMINAL_SIZE --title='Hey Claude' --"
+                    TERMINAL_CMD=(
+                        "$term"
+                        "--geometry=$DEFAULT_TERMINAL_SIZE"
+                        "--title"
+                        "Hey Claude"
+                        "--"
+                    )
                     ;;
                 konsole)
-                    TERMINAL_CMD="$term --geometry=$DEFAULT_TERMINAL_SIZE --title='Hey Claude' -e"
+                    TERMINAL_CMD=(
+                        "$term"
+                        "--geometry=$DEFAULT_TERMINAL_SIZE"
+                        "--title"
+                        "Hey Claude"
+                        "-e"
+                    )
                     ;;
                 alacritty)
-                    TERMINAL_CMD="$term --title 'Hey Claude' -e"
+                    TERMINAL_CMD=(
+                        "$term"
+                        "--title"
+                        "Hey Claude"
+                        "-e"
+                    )
                     ;;
                 kitty)
-                    TERMINAL_CMD="$term --title='Hey Claude' --"
+                    TERMINAL_CMD=(
+                        "$term"
+                        "--title"
+                        "Hey Claude"
+                        "--"
+                    )
                     ;;
                 xterm|terminator)
-                    TERMINAL_CMD="$term -geometry $DEFAULT_TERMINAL_SIZE -title 'Hey Claude' -e"
+                    TERMINAL_CMD=(
+                        "$term"
+                        "-geometry"
+                        "$DEFAULT_TERMINAL_SIZE"
+                        "-title"
+                        "Hey Claude"
+                        "-e"
+                    )
                     ;;
             esac
             return 0
         fi
     done
 
-    TERMINAL_CMD=""
+    TERMINAL_CMD=()
     return 0
 }
 
@@ -465,9 +500,9 @@ detect_terminal
 if [[ -t 0 && -t 1 && -t 2 ]] || [[ "${HEYCLAUDE_TEST_MODE:-}" == "1" ]]; then
     # Running inside an interactive terminal already
     main
-elif [[ -n "$TERMINAL_CMD" ]]; then
+elif (( ${#TERMINAL_CMD[@]} )); then
     # Launch the script inside the detected terminal emulator
-    exec $TERMINAL_CMD "$0" "$@"
+    exec "${TERMINAL_CMD[@]}" "$0" "$@"
 else
     # No terminal available to launch the interactive experience
     error "Unable to locate a terminal emulator. Run Hey Claude from a terminal or set the TERMINAL environment variable to your preferred launcher."

--- a/tests/test_terminal_launch.sh
+++ b/tests/test_terminal_launch.sh
@@ -18,6 +18,33 @@ if ! grep -q "# Hey Claude - Ultralight CLI for Claude" "$EXEC_OUTPUT"; then
     exit 1
 fi
 
+# Provide a mock gnome-terminal whose arguments contain spaces to ensure the
+# array-based TERMINAL_CMD launches correctly.
+GNOME_LOG="$TMP_DIR/gnome.log"
+cat <<'EOF' >"$TMP_DIR/gnome-terminal"
+#!/usr/bin/env bash
+printf '%s\n' "$@" >"$GNOME_LOG"
+EOF
+chmod +x "$TMP_DIR/gnome-terminal"
+
+GNOME_STDOUT="$TMP_DIR/gnome.out"
+GNOME_STDERR="$TMP_DIR/gnome.err"
+PATH="$TMP_DIR:/usr/bin:/bin" bash "$PROJECT_ROOT/heyclaude" \
+    </dev/null >"$GNOME_STDOUT" 2>"$GNOME_STDERR"
+
+if [[ ! -s "$GNOME_LOG" ]]; then
+    echo "Expected mock gnome-terminal to record invocation" >&2
+    exit 1
+fi
+
+mapfile -t GNOME_ARGS <"$GNOME_LOG"
+if [[ "${GNOME_ARGS[1]}" != "--title" ]] || [[ "${GNOME_ARGS[2]}" != "Hey Claude" ]]; then
+    echo "gnome-terminal arguments were not passed as discrete array elements" >&2
+    printf 'Captured args:\n'
+    printf '  %s\n' "${GNOME_ARGS[@]}"
+    exit 1
+fi
+
 # Without a TTY and no detected terminal, the script should fail with a
 # friendly error message instead of invoking main.
 ERROR_STDOUT="$TMP_DIR/error.out"


### PR DESCRIPTION
## Summary
- store detected terminal launchers as arrays and execute them with array expansion to preserve arguments
- mirror the array handling in the bundled test harness and refresh documentation of the entrypoint flow
- add a mock gnome-terminal scenario to the terminal launch test to prove spaced arguments are preserved

## Testing
- bash tests/test_terminal_launch.sh
- bash tests/test_operators.sh
- bash tests/test_prompt_building.sh

------
https://chatgpt.com/codex/tasks/task_e_68d180d0ffec83219e96e0217f6208ba